### PR TITLE
Pendiente de revisar porque main falla al importar

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,5 @@
+from selector.selector import menu_seleccion
+
+print("\n------ Bienvenido a mi Coleccion de Miniprogramas en Python ------\n")
+
+menu_seleccion()

--- a/selector/opciones.py
+++ b/selector/opciones.py
@@ -1,0 +1,22 @@
+import inquirer
+
+def mi_opcion():
+    opciones = [
+        "Calculo de Secuencia de Fibonacci",
+        "Implementacion de Persona",
+        "Conversor Decimal a Binario",
+        "Conversor Binario a Decimal",
+        "Calculadora de Factoriales",
+    ]
+
+    menu = [
+        inquirer.List(
+            "opcion",
+            message="Selecciona la opcion que deseas explorar:",
+            choices=opciones,
+        )
+    ]
+
+    opcion = inquirer.prompt(menu)
+
+    return opcion

--- a/selector/selector.py
+++ b/selector/selector.py
@@ -1,0 +1,5 @@
+from opciones import mi_opcion
+
+def menu_seleccion():
+    final = mi_opcion()
+    return final["opcion"]


### PR DESCRIPTION
Al intentar ejecutar python main.py, el interprete da el siguiente error:

```
Traceback (most recent call last):
  File "/home/jalejotorresm/Documents/Programming/Python/implementations_python/main.py", line 1, in <module>
    from selector.selector import menu_seleccion
  File "/home/jalejotorresm/Documents/Programming/Python/implementations_python/selector/selector.py", line 1, in <module>
    from opciones import mi_opcion
ModuleNotFoundError: No module named 'opciones'
```

Sin embargo al ejecutar selector y opciones por separado, el programa no arroja errores.